### PR TITLE
Construct params explicity

### DIFF
--- a/lib/request.ex
+++ b/lib/request.ex
@@ -52,7 +52,8 @@ defmodule Request.Validator do
 
       @spec validate(Plug.Conn.t() | map()) :: Request.Validator.validation_result()
       def validate(%Plug.Conn{} = conn) do
-        Request.Validator.validate(__MODULE__, conn.params, unquote(opts) ++ [conn: conn])
+        params = conn.query_params |> Map.merge(conn.body_params) |> Map.merge(conn.path_params)
+        Request.Validator.validate(__MODULE__, params, unquote(opts) ++ [conn: conn])
       end
 
       def validate(params) when is_map(params) do


### PR DESCRIPTION
For some reason, extraneous fields that do not exist in `query_params`, `body_params` or `path_params` (e.g. `path`) are being added to `params` and causing validation to fail when strict mode is activated. 
A quick workaround is constructing `params` the way `Plug` [does](https://github.com/elixir-plug/plug/blob/2e078cf207e6f954e2397e305f05409301c8eee8/lib/plug/parsers.ex#L379-L382).